### PR TITLE
Rename st2 version alias

### DIFF
--- a/actions/st2_version.yaml
+++ b/actions/st2_version.yaml
@@ -10,7 +10,7 @@
       required: true
       enum:
         - stable
-        - unstable
+        - latest
     cmd:
-      default: "curl -Ss -q https://downloads.stackstorm.net/deb/pool/trusty_{{branch}}/main/s/st2api/ | grep 'amd64.deb' | sed -e 's~.*>st2api_\\(.*\\)-.*<.*~\\1~g' | sort --version-sort -r | uniq | head -n 1"
+      default: "curl -Ss -q https://downloads.stackstorm.net/deb/pool/trusty_{{branch|replace('latest', 'unstable')}}/main/s/st2api/ | grep 'amd64.deb' | sed -e 's~.*>st2api_\\(.*\\)-.*<.*~\\1~g' | sort --version-sort -r | uniq | head -n 1"
       immutable: true

--- a/actions/st2_version.yaml
+++ b/actions/st2_version.yaml
@@ -5,12 +5,12 @@
   description: "Get the latest stable or unstable version of St2"
   enabled: true
   parameters:
-    version:
+    branch:
       type: "string"
       required: true
       enum:
         - stable
         - unstable
     cmd:
-      default: "curl -Ss -q https://downloads.stackstorm.net/deb/pool/trusty_{{version}}/main/s/st2api/ | grep 'amd64.deb' | sed -e 's~.*>st2api_\\(.*\\)-.*<.*~\\1~g' | sort --version-sort -r | uniq | head -n 1"
+      default: "curl -Ss -q https://downloads.stackstorm.net/deb/pool/trusty_{{branch}}/main/s/st2api/ | grep 'amd64.deb' | sed -e 's~.*>st2api_\\(.*\\)-.*<.*~\\1~g' | sort --version-sort -r | uniq | head -n 1"
       immutable: true

--- a/aliases/release.yaml
+++ b/aliases/release.yaml
@@ -1,7 +1,0 @@
----
-name: "released"
-action_ref: "community.st2_version"
-formats:
-  - "released {{version}}"
-  - "latest {{version}} StackStorm"
-  - "latest {{version}} st2"

--- a/aliases/version.yaml
+++ b/aliases/version.yaml
@@ -1,6 +1,6 @@
 ---
 name: "version"
 action_ref: "community.st2_version"
-description: "Show the StackStorm version"
+description: "Show latest StackStorm version for specific branch"
 formats:
   - "st2 version {{branch=stable}}"

--- a/aliases/version.yaml
+++ b/aliases/version.yaml
@@ -1,0 +1,6 @@
+---
+name: "version"
+action_ref: "community.st2_version"
+description: "Show the StackStorm version"
+formats:
+  - "st2 version {{branch=stable}}"


### PR DESCRIPTION
This looks a bit more clear: 

`!st2 version`
`!st2 version stable`
`!st2 version unstable`

Also feels like single alias to show the version is enough, not to spam/overload list of commands: `!help`.
