### PR TITLE
st2 Release Notification in Slack community

### DIFF
--- a/rules/release_notification.yaml
+++ b/rules/release_notification.yaml
@@ -11,6 +11,10 @@
     trigger.type:
       type: "equals"
       pattern: "ReleaseEvent"
+    # don't spam in chat with all versions at the first run
+    trigger.created_at:
+      type: "timediff_lt"
+      pattern: 86400
 
   action:
     ref: "slack.post_message"

--- a/rules/release_notification.yaml
+++ b/rules/release_notification.yaml
@@ -1,0 +1,19 @@
+---
+  name: "release_notification"
+  description: "Send Slack message when new repository version is released in GitHub"
+  enabled: true
+
+  trigger:
+    type: "github.repository_event"
+    parameters: {}
+
+  criteria:
+    trigger.type:
+      type: "equals"
+      pattern: "ReleaseEvent"
+
+  action:
+    ref: "slack.post_message"
+    parameters:
+      message: "New *{{trigger.repository}}* version `{{trigger.payload.release.tag_name}}` is released!\n ```{{trigger.payload.release.body}}```\n {{trigger.payload.release.html_url}}"
+      channel: "#events"


### PR DESCRIPTION
Implements #2, Slack notifications when new version of `st2` is released: 
![](http://i.imgur.com/JUzilkI.png)

[GitHub pack](https://github.com/StackStorm/st2contrib/tree/master/packs/github) with auth token in config is required.
