### PR TITLE
Add create_issue

### DIFF
--- a/actions/chains/create_issue.yaml
+++ b/actions/chains/create_issue.yaml
@@ -1,0 +1,10 @@
+---
+  chain:
+    -
+      name: "post_github_issue"
+      ref: "st2-community.create_issue"
+      params:
+        title: "{{title}}"
+        description: "{{description}}"
+        repo: "st2"
+        user: "StackStorm"

--- a/actions/chains/create_issue.yaml
+++ b/actions/chains/create_issue.yaml
@@ -1,8 +1,8 @@
 ---
   chain:
     -
-      name: "post_github_issue"
-      ref: "st2-community.create_issue"
+      name: "create_github_issue"
+      ref: "github.create_issue"
       params:
         title: "{{title}}"
         description: "{{description}}"

--- a/actions/create_issue.yaml
+++ b/actions/create_issue.yaml
@@ -1,0 +1,15 @@
+---
+name: "create_issue"
+description: "Create an issue for StackStorm/st2"
+runner_type: "action-chain"
+entry_point: "chains/create_issue.yaml"
+enabled: true
+parameters:
+  title:
+    type: "string"
+    description: "Title of new issue"
+    required: true
+  description:
+    type: "string"
+    description: "Details of issue"
+    required: true

--- a/actions/create_issue.yaml
+++ b/actions/create_issue.yaml
@@ -13,3 +13,6 @@ parameters:
     type: "string"
     description: "Details of issue"
     required: true
+  skip_notify:
+    default:
+      - "create_github_issue"

--- a/aliases/create_issue.yaml
+++ b/aliases/create_issue.yaml
@@ -3,5 +3,5 @@ name: "create_issue"
 pack: "st2-community"
 action_ref: "st2-community.create_issue"
 formats:
-  - "issue {{title}} {{description}}"
+  - "issue create {{title}} {{description}}"
 description: "File a StackStorm issue from ChatOps"

--- a/aliases/create_issue.yaml
+++ b/aliases/create_issue.yaml
@@ -1,8 +1,7 @@
 ---
 name: "create_issue"
 pack: "st2-community"
-action_ref: "github.create_issue"
+action_ref: "st2-community.create_issue"
 formats:
-  - "issue create {{user}}/{{repo}} {{title}}"
-  - ":bug: create {{user}}/{{repo}} {{title}}"
-description: "File a GitHub issue from ChatOps"
+  - "issue {{title}} {{description}}"
+description: "File a StackStorm issue from ChatOps"

--- a/aliases/create_issue.yaml
+++ b/aliases/create_issue.yaml
@@ -1,0 +1,8 @@
+---
+name: "create_issue"
+pack: "st2-community"
+action_ref: "github.create_issue"
+formats:
+  - "issue create {{user}}/{{repo}} {{title}}"
+  - ":bug: create {{user}}/{{repo}} {{title}}"
+description: "File a GitHub issue from ChatOps"


### PR DESCRIPTION
This commit adds initial support for the ChatOps alias to post issues automatically to GitHub.
