### PR TITLE
Disabling release notifications

### DIFF
--- a/rules/release_notification.yaml
+++ b/rules/release_notification.yaml
@@ -2,7 +2,7 @@
   name: "release_notification"
   pack: "st2-community"
   description: "Send Slack message when new repository version is released in GitHub"
-  enabled: true
+  enabled: false
 
   trigger:
     type: "github.repository_event"


### PR DESCRIPTION
As discussed, disabling the rule to have control over when and where people are notified about the release. This is still a nice feature to have, even if it creates some confusion with our current workflow, so I'm not removing the rule in the hope we can leverage it in the future.

Also disabled the actual rule on pinkiepie.
